### PR TITLE
refactor: ship completion files on win

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -16,18 +16,29 @@ source:
     target_directory: library_licenses_2/github.com/go-localereader
 
 build:
-  number: 0
+  number: 1
   script:
     - cd src
     - go-licenses save ./cmd/bd --save_path ../library_licenses --ignore github.com/mattn/go-localereader
     - if: unix
       then:
         - go build -v -o $PREFIX/bin/bd -ldflags="-s -w -X main.version=${{ version }}" ./cmd/bd
-        - mkdir -p $PREFIX/share/zsh/site-functions $PREFIX/share/bash-completion/completions $PREFIX/share/fish/vendor_completions.d
-        - $PREFIX/bin/bd completion zsh > $PREFIX/share/zsh/site-functions/_bd
+        # generate shell completions
+        - mkdir -p $PREFIX/share/bash-completion/completions $PREFIX/share/fish/vendor_completions.d $PREFIX/share/zsh/site-functions
         - $PREFIX/bin/bd completion bash > $PREFIX/share/bash-completion/completions/bd
         - $PREFIX/bin/bd completion fish > $PREFIX/share/fish/vendor_completions.d/bd.fish
-      else: go build -v -o %LIBRARY_BIN%\bd.exe -ldflags="-s -X main.version=${{ version }}" ./cmd/bd
+        - $PREFIX/bin/bd completion zsh > $PREFIX/share/zsh/site-functions/_bd
+    - if: win
+      then:
+        - go build -v -o %LIBRARY_BIN%\bd.exe -ldflags="-s -X main.version=${{ version }}" ./cmd/bd
+        # generate shell completions
+        - mkdir %LIBRARY_PREFIX%\share\bash-completion\completions
+        - mkdir %LIBRARY_PREFIX%\share\fish\vendor_completions.d
+        - mkdir %LIBRARY_PREFIX%\share\zsh\site-functions
+        - '%LIBRARY_BIN%\bd.exe completion bash > %LIBRARY_PREFIX%\share\bash-completion\completions\bd'
+        - '%LIBRARY_BIN%\bd.exe completion fish > %LIBRARY_PREFIX%\share\fish\vendor_completions.d\bd.fish'
+        - '%LIBRARY_BIN%\bd.exe completion zsh > %LIBRARY_PREFIX%\share\zsh\site-functions\_bd'
+
 requirements:
   build:
     - ${{ compiler("go-nocgo") }}
@@ -35,10 +46,8 @@ requirements:
 
 tests:
   - script:
-      - if: build_platform == host_platform
-        then:
-          - bd --version
-          - bd --help
+      - bd --version
+      - bd --help
   - package_contents:
       bin:
         - bd
@@ -48,6 +57,11 @@ tests:
             - share/bash-completion/completions/bd
             - share/fish/vendor_completions.d/bd.fish
             - share/zsh/site-functions/_bd
+        - if: win
+          then:
+            - Library/share/bash-completion/completions/bd
+            - Library/share/fish/vendor_completions.d/bd.fish
+            - Library/share/zsh/site-functions/_bd
       strict: true
 
 about:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   - url: https://github.com/steveyegge/beads/archive/refs/tags/v${{ version }}.tar.gz
-    sha256: ab365337edf2109880e878017d15d3172cd748d4229872c08c9bb794a5335d19
+    sha256: db089aa41a3aa1f68f57ad72b632e2796dd5a045406366a68e001450889f0370
     target_directory: src
   # Windows-only dep `go-localereader` (MIT-licensed) misses standard license file layout,
   # so we have to manually add it


### PR DESCRIPTION
and drop unnused constraints and correct SHA256 sum value for v1.0.0 release (v1.0.0 was re-released with two more commits, cf. https://github.com/gastownhall/beads/commits/v1.0.0/)

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
