### PR TITLE
refactor: tweak build flags

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -10,19 +10,18 @@ source:
     sha256: db089aa41a3aa1f68f57ad72b632e2796dd5a045406366a68e001450889f0370
     target_directory: src
   # Windows-only dep `go-localereader` (MIT-licensed) misses standard license file layout,
-  # so we have to manually add it
+  # so we have to manually add the license file
   - url: https://raw.githubusercontent.com/mattn/go-localereader/master/LICENSE
     sha256: dceede03550621e65ec7b79fcba87cf6dbb9d31132a8ae71a8fe8ceec0af7da3
     target_directory: library_licenses_2/github.com/go-localereader
 
 build:
-  number: 1
+  number: 2
   script:
     - cd src
-    - go-licenses save ./cmd/bd --save_path ../library_licenses --ignore github.com/mattn/go-localereader
     - if: unix
       then:
-        - go build -v -o $PREFIX/bin/bd -ldflags="-s -w -X main.version=${{ version }}" ./cmd/bd
+        - go build -v -o $PREFIX/bin/bd -ldflags="-s -w -X main.version=${{ version }}" -trimpath ./cmd/bd
         # generate shell completions
         - mkdir -p $PREFIX/share/bash-completion/completions $PREFIX/share/fish/vendor_completions.d $PREFIX/share/zsh/site-functions
         - $PREFIX/bin/bd completion bash > $PREFIX/share/bash-completion/completions/bd
@@ -30,7 +29,7 @@ build:
         - $PREFIX/bin/bd completion zsh > $PREFIX/share/zsh/site-functions/_bd
     - if: win
       then:
-        - go build -v -o %LIBRARY_BIN%\bd.exe -ldflags="-s -X main.version=${{ version }}" ./cmd/bd
+        - go build -v -o %LIBRARY_BIN%\bd.exe -ldflags="-s -w -X main.version=${{ version }}" -trimpath ./cmd/bd
         # generate shell completions
         - mkdir %LIBRARY_PREFIX%\share\bash-completion\completions
         - mkdir %LIBRARY_PREFIX%\share\fish\vendor_completions.d
@@ -38,6 +37,7 @@ build:
         - '%LIBRARY_BIN%\bd.exe completion bash > %LIBRARY_PREFIX%\share\bash-completion\completions\bd'
         - '%LIBRARY_BIN%\bd.exe completion fish > %LIBRARY_PREFIX%\share\fish\vendor_completions.d\bd.fish'
         - '%LIBRARY_BIN%\bd.exe completion zsh > %LIBRARY_PREFIX%\share\zsh\site-functions\_bd'
+    - go-licenses save ./cmd/bd --save_path ../library_licenses --ignore github.com/mattn/go-localereader
 
 requirements:
   build:


### PR DESCRIPTION
- enable the `-w` ldflag on win, too
- add the `-trimpath` flag to improve reproducibility
- cosmetic changes

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
